### PR TITLE
Fix sample app: nested paths during decoding, supporting optional values

### DIFF
--- a/Sources/MarkCodable/Decoder/MarkKeyedDecoding.swift
+++ b/Sources/MarkCodable/Decoder/MarkKeyedDecoding.swift
@@ -39,8 +39,8 @@ struct MarkKeyedDecoding<Key: CodingKey>: KeyedDecodingContainerProtocol {
         default: break
         }
 
-        let nestedKey = codingPath + [key]
-        let decoding = MarkDecoding(codingPath: nestedKey, userInfo: userInfo, from: data)
+        let nestedPath = codingPath + [key]
+        let decoding = MarkDecoding(codingPath: nestedPath, userInfo: userInfo, from: data)
         return try T.init(from: decoding)
     }
 

--- a/Sources/MarkCodable/Decoder/MarkKeyedDecoding.swift
+++ b/Sources/MarkCodable/Decoder/MarkKeyedDecoding.swift
@@ -18,6 +18,15 @@ struct MarkKeyedDecoding<Key: CodingKey>: KeyedDecodingContainerProtocol {
         return data.keys.contains(key.stringValue)
     }
 
+    // TODO: This is likely needed for all other primitives and requires testing.
+    func decodeIfPresent(_ type: String.Type, forKey key: Key) throws -> String? {
+        let nestedPath = codingPath + [key]
+        let decoding = MarkDecoding(codingPath: nestedPath, userInfo: userInfo, from: data)
+        let value = try String(from: decoding)
+        guard !value.isEmpty else { return nil }
+        return value
+    }
+
     func decodeIfPresent<T>(_ type: T.Type, forKey key: Key) throws -> T? where T : Decodable {
         // TODO: Test if we handle optional URL/custom types properly like decode<T>
 

--- a/Sources/MarkCodable/Decoder/MarkKeyedDecoding.swift
+++ b/Sources/MarkCodable/Decoder/MarkKeyedDecoding.swift
@@ -80,7 +80,8 @@ struct MarkKeyedDecoding<Key: CodingKey>: KeyedDecodingContainerProtocol {
     }
 
     private func unbox<T: Decodable & StringInitializable>(_ key: Key) throws -> T {
-        guard let value = data[key.stringValue] else {
+        let nestedPath = codingPath + [key]
+        guard let value = data[nestedPath.absoluteString] else {
             throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: codingPath, debugDescription: "No value associated with key \(key) (\"\(key.stringValue)\")."))
         }
         guard let unwrappedValue = value else {

--- a/Sources/MarkCodable/Decoder/MarkKeyedDecoding.swift
+++ b/Sources/MarkCodable/Decoder/MarkKeyedDecoding.swift
@@ -13,7 +13,7 @@ struct MarkKeyedDecoding<Key: CodingKey>: KeyedDecodingContainerProtocol {
     }
 
     func contains(_ key: Key) -> Bool {
-        data.keys.contains(key.stringValue)
+        return data.keys.contains(key.stringValue)
     }
 
     func decodeNil(forKey key: Key) throws -> Bool {

--- a/Sources/MarkCodable/Decoder/MarkKeyedDecoding.swift
+++ b/Sources/MarkCodable/Decoder/MarkKeyedDecoding.swift
@@ -16,8 +16,16 @@ struct MarkKeyedDecoding<Key: CodingKey>: KeyedDecodingContainerProtocol {
         return data.keys.contains(key.stringValue)
     }
 
+    func decodeIfPresent<T>(_ type: T.Type, forKey key: Key) throws -> T? where T : Decodable {
+        // TODO: Handle optional URL
+        let nestedPath = codingPath + [key]
+        let decoding = MarkDecoding(codingPath: nestedPath, userInfo: userInfo, from: data)
+        return try T.init(from: decoding)
+    }
+
     func decodeNil(forKey key: Key) throws -> Bool {
-        guard let value = data[key.stringValue] else {
+        let nestedPath = codingPath + [key]
+        guard let value = data[nestedPath.absoluteString] else {
             throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: codingPath, debugDescription: "No value associated with key \(key) (\"\(key.stringValue)\")."))
         }
         return value == ""

--- a/Sources/MarkCodable/Decoder/MarkKeyedDecoding.swift
+++ b/Sources/MarkCodable/Decoder/MarkKeyedDecoding.swift
@@ -54,7 +54,7 @@ struct MarkKeyedDecoding<Key: CodingKey>: KeyedDecodingContainerProtocol {
     func decode<T>(_ type: T.Type, forKey key: Key) throws -> T where T : Decodable {
         switch T.self {
         case is URL.Type:
-            guard let optionalValue = data[key.stringValue],
+            guard let optionalValue = data[key.stringValue], // TODO: Add tests if nestedPath is needed
                   let value = optionalValue,
                   let url = URL(string: value) else {
                 throw DecodingError.typeMismatch(URL.self, DecodingError.Context(codingPath: codingPath, debugDescription: "Could not parse URL value for key \(codingPath)"))

--- a/Sources/MarkCodable/Encoder/MarkKeyedEncoding.swift
+++ b/Sources/MarkCodable/Encoder/MarkKeyedEncoding.swift
@@ -14,6 +14,15 @@ struct MarkKeyedEncoding<Key: CodingKey>: KeyedEncodingContainerProtocol {
         self.data = data
     }
 
+    // TODO: This is likely needed for all other primitives and requires testing.
+    mutating func encodeIfPresent(_ value: String?, forKey key: Key) throws {
+        if let value = value {
+            try encode(value, forKey: key)
+        } else {
+            try encodeNil(forKey: key)
+        }
+    }
+
     mutating func encodeIfPresent<T>(_ value: T?, forKey key: Key) throws where T : Encodable {
         if let value = value {
             try encode(value, forKey: key)

--- a/Sources/MarkCodable/Encoder/MarkKeyedEncoding.swift
+++ b/Sources/MarkCodable/Encoder/MarkKeyedEncoding.swift
@@ -14,6 +14,14 @@ struct MarkKeyedEncoding<Key: CodingKey>: KeyedEncodingContainerProtocol {
         self.data = data
     }
 
+    mutating func encodeIfPresent<T>(_ value: T?, forKey key: Key) throws where T : Encodable {
+        if let value = value {
+            try encode(value, forKey: key)
+        } else {
+            try encodeNil(forKey: key)
+        }
+    }
+
     mutating func encodeNil(forKey key: Key) throws {
         data.encode(key: codingPath + [key], value: "")
     }

--- a/Sources/MarkCodable/Encoder/MarkKeyedEncoding.swift
+++ b/Sources/MarkCodable/Encoder/MarkKeyedEncoding.swift
@@ -63,7 +63,3 @@ struct MarkKeyedEncoding<Key: CodingKey>: KeyedEncodingContainerProtocol {
         return MarkEncoding(codingPath: codingPath + [key], userInfo: userInfo, to: data)
     }
 }
-
-extension MarkKeyedEncoding {
-
-}

--- a/Sources/MarkTestApp/main.swift
+++ b/Sources/MarkTestApp/main.swift
@@ -14,9 +14,9 @@ struct House: Codable {
     var street: String
     var number: Int
     var price: Price
-    
+
     struct Price: Codable {
-        var price: Double
+        var amount: Double
         var currency: String
         var conversionRate: Float?
     }
@@ -24,7 +24,7 @@ struct House: Codable {
 
 // Markdown input
 let input = """
-| street | number | price.price | price.currency | isSocial | price.conversionRate |
+| street | number | price.amount | price.currency | isSocial | price.conversionRate |
 |----------| ------ | ---| --- | -- | - |
 | main st. | 134 | 1234.32 | USD | false     | |
 | Secondary st. | 24 | 9234.32 | JPY | true| 24.28 |

--- a/Tests/MarkCodableTests/MarkCoderTests.swift
+++ b/Tests/MarkCodableTests/MarkCoderTests.swift
@@ -238,14 +238,15 @@ final class MarkCoderTests: XCTestCase {
             strings: [],
             bools: [],
             optionalBools: [nil],
-            custom: []
+            custom: [],
+            urls: nil
         )
 
         let encoded = try encoder.encode([lists])
         XCTAssertEqual(encoded, """
-        |bools|custom|optionalBools|strings|
-        |-----|------|-------------|-------|
-        |     |      |nil          |       |
+        |bools|custom|ints|optionalBools|strings|urls|
+        |-----|------|----|-------------|-------|----|
+        |     |      |    |nil          |       |    |
         """)
 
         let decoded = try decoder.decode(Lists.self, string: encoded)

--- a/Tests/MarkCodableTests/MarkCoderTests.swift
+++ b/Tests/MarkCodableTests/MarkCoderTests.swift
@@ -102,22 +102,20 @@ final class MarkCoderTests: XCTestCase {
         var optional = optionalNilHouse
         let encoded2 = try encoder.encode(optional)
         XCTAssertEqual(encoded2, """
-        ||
-        ||
-        ||
+        |name|
+        |----|
+        |    |
         """)
 
-        // TODO: the encoder produces an invalid markdown table
-        // https://github.com/icanzilb/MarkCodable/issues/1
-        // let decoded2 = try decoder.decode([OptionalHouse].self, string: encoded2)
-        // XCTAssertEqual(decoded2, [optional])
+        let decoded2 = try decoder.decode([OptionalHouse].self, string: encoded2)
+        XCTAssertEqual(decoded2, [optional])
 
         optional.isNewlyBuilt = true
         let encoded3 = try encoder.encode(optional)
         XCTAssertEqual(encoded3, """
-        |isNewlyBuilt|
-        |------------|
-        |true        |
+        |isNewlyBuilt|name|
+        |------------|----|
+        |true        |    |
         """)
 
         let decoded3 = try decoder.decode([OptionalHouse].self, string: encoded3)
@@ -126,9 +124,9 @@ final class MarkCoderTests: XCTestCase {
         optional.numberWindows = 10_000
         let encoded4 = try encoder.encode(optional)
         XCTAssertEqual(encoded4, """
-        |isNewlyBuilt|numberWindows|
-        |------------|-------------|
-        |true        |10000        |
+        |isNewlyBuilt|name|numberWindows|
+        |------------|----|-------------|
+        |true        |    |10000        |
         """)
 
         let decoded4 = try decoder.decode([OptionalHouse].self, string: encoded4)
@@ -361,7 +359,6 @@ final class MarkCoderTests: XCTestCase {
         let encoder = MarkEncoder()
         let decoder = MarkDecoder()
 
-        // FIXME: This currently fails, needs discussion.
         let singleNilMarkdown = """
         |optionalString|
         |--------------|

--- a/Tests/MarkCodableTests/MarkCoderTests.swift
+++ b/Tests/MarkCodableTests/MarkCoderTests.swift
@@ -350,6 +350,34 @@ final class MarkCoderTests: XCTestCase {
         XCTAssertEqual(value, try decoder.decode(SingleString.self, string: markdown))
     }
 
+    func testSingleOptionalString() throws {
+        struct SingleOptionalString: Codable, Equatable {
+            var optionalString: String?
+        }
+
+        let encoder = MarkEncoder()
+        let decoder = MarkDecoder()
+
+        // FIXME: This currently fails, needs discussion.
+        let singleNilMarkdown = """
+        |optionalString|
+        |--------------|
+        |              |
+        """
+        let nilValue = SingleOptionalString(optionalString: nil)
+        XCTAssertEqual(singleNilMarkdown, try encoder.encode(nilValue))
+        XCTAssertEqual(nilValue, try decoder.decode(SingleOptionalString.self, string: singleNilMarkdown))
+
+        let singleNonNilMarkdown = """
+        |optionalString|
+        |--------------|
+        |yes           |
+        """
+        let existingValue = SingleOptionalString(optionalString: "yes")
+        XCTAssertEqual(singleNonNilMarkdown, try encoder.encode(existingValue))
+        XCTAssertEqual(existingValue, try decoder.decode(SingleOptionalString.self, string: singleNonNilMarkdown))
+    }
+
     func testNestedTypes() throws {
         let markdown = """
         |optionalPig.name|pig.name|

--- a/Tests/MarkCodableTests/MarkCoderTests.swift
+++ b/Tests/MarkCodableTests/MarkCoderTests.swift
@@ -349,4 +349,19 @@ final class MarkCoderTests: XCTestCase {
         XCTAssertEqual(markdown, try encoder.encode(value))
         XCTAssertEqual(value, try decoder.decode(SingleString.self, string: markdown))
     }
+
+    func testNestedTypes() throws {
+        let markdown = """
+        |pig.name|
+        |--------|
+        |Snowball|
+        """
+
+        let encoder = MarkEncoder()
+        let decoder = MarkDecoder()
+
+        XCTAssertEqual(try encoder.encode(animalFarm1), markdown)
+
+        XCTAssertEqual(try decoder.decode(AnimalFarm.self, string: markdown), animalFarm1)
+    }
 }

--- a/Tests/MarkCodableTests/MarkCoderTests.swift
+++ b/Tests/MarkCodableTests/MarkCoderTests.swift
@@ -351,7 +351,8 @@ final class MarkCoderTests: XCTestCase {
         XCTAssertEqual(value, try decoder.decode(SingleString.self, string: markdown))
     }
 
-    func testSingleOptionalString() throws {
+    // TODO: Add variants for all other encodable primites to verify we correctly produce a column header even when there's no data.
+    func testSingleOptionalStringColumn() throws {
         struct SingleOptionalString: Codable, Equatable {
             var optionalString: String?
         }
@@ -376,6 +377,36 @@ final class MarkCoderTests: XCTestCase {
         let existingValue = SingleOptionalString(optionalString: "yes")
         XCTAssertEqual(singleNonNilMarkdown, try encoder.encode(existingValue))
         XCTAssertEqual(existingValue, try decoder.decode(SingleOptionalString.self, string: singleNonNilMarkdown))
+
+        let multipleNilsMarkdown = """
+        |optionalString|
+        |--------------|
+        |              |
+        |              |
+        |              |
+        """
+        let multipleNilValues = [
+          SingleOptionalString(optionalString: nil),
+          SingleOptionalString(optionalString: nil),
+          SingleOptionalString(optionalString: nil),
+        ]
+        XCTAssertEqual(multipleNilsMarkdown, try encoder.encode(multipleNilValues))
+        XCTAssertEqual(multipleNilValues, try decoder.decode([SingleOptionalString].self, string: multipleNilsMarkdown))
+
+       let multipleMixedMarkdown = """
+        |optionalString|
+        |--------------|
+        |              |
+        |mixed         |
+        |              |
+        """
+        let multipleMixedValues = [
+          SingleOptionalString(optionalString: nil),
+          SingleOptionalString(optionalString: "mixed"),
+          SingleOptionalString(optionalString: nil),
+        ]
+        XCTAssertEqual(multipleMixedMarkdown, try encoder.encode(multipleMixedValues))
+        XCTAssertEqual(multipleMixedValues, try decoder.decode([SingleOptionalString].self, string: multipleMixedMarkdown))
     }
 
     func testNestedTypes() throws {

--- a/Tests/MarkCodableTests/MarkCoderTests.swift
+++ b/Tests/MarkCodableTests/MarkCoderTests.swift
@@ -411,16 +411,15 @@ final class MarkCoderTests: XCTestCase {
 
     func testNestedTypes() throws {
         let markdown = """
-        |optionalPig.name|pig.name|
-        |----------------|--------|
-        |Snowball        |Napoleon|
+        |optionalPig.color|optionalPig.name|pig.color|pig.name|
+        |-----------------|----------------|---------|--------|
+        |pink             |Snowball        |         |Napoleon|
         """
 
         let encoder = MarkEncoder()
         let decoder = MarkDecoder()
 
         XCTAssertEqual(try encoder.encode(animalFarm1), markdown)
-
         XCTAssertEqual(try decoder.decode(AnimalFarm.self, string: markdown), animalFarm1)
     }
 }

--- a/Tests/MarkCodableTests/MarkCoderTests.swift
+++ b/Tests/MarkCodableTests/MarkCoderTests.swift
@@ -352,9 +352,9 @@ final class MarkCoderTests: XCTestCase {
 
     func testNestedTypes() throws {
         let markdown = """
-        |pig.name|
-        |--------|
-        |Snowball|
+        |optionalPig.name|pig.name|
+        |----------------|--------|
+        |Snowball        |Napoleon|
         """
 
         let encoder = MarkEncoder()

--- a/Tests/MarkCodableTests/Utility/TestData.swift
+++ b/Tests/MarkCodableTests/Utility/TestData.swift
@@ -59,3 +59,9 @@ let blog1 = Blog(
     address: URL(string: "https://daringfireball.net")!,
     pageNotFound: URL(string: "https://daringfireball.net/zxcglj/#fragment?param=1")!
 )
+
+// Animal Farm
+
+let animalFarm1 = AnimalFarm(
+  pig: .init(name: "Snowball")
+)

--- a/Tests/MarkCodableTests/Utility/TestData.swift
+++ b/Tests/MarkCodableTests/Utility/TestData.swift
@@ -58,5 +58,6 @@ let blog1 = Blog(
 // Animal Farm
 
 let animalFarm1 = AnimalFarm(
-  pig: .init(name: "Snowball")
+  pig: .init(name: "Napoleon", color: nil),
+  optionalPig: .init(name: "Snowball", color: "pink")
 )

--- a/Tests/MarkCodableTests/Utility/TestModels.swift
+++ b/Tests/MarkCodableTests/Utility/TestModels.swift
@@ -115,8 +115,10 @@ struct ListContainer<T: Codable>: Codable {
 
 struct AnimalFarm: Codable, Equatable {
     let pig: Pig
+    let optionalPig: Pig?
 
     struct Pig: Codable, Equatable {
         let name: String
+        let color: String?
     }
 }

--- a/Tests/MarkCodableTests/Utility/TestModels.swift
+++ b/Tests/MarkCodableTests/Utility/TestModels.swift
@@ -117,3 +117,11 @@ struct Lists: Codable, Equatable {
 struct ListContainer<T: Codable>: Codable {
     let numbers: Array<T>
 }
+
+struct AnimalFarm: Codable, Equatable {
+    let pig: Pig
+
+    struct Pig: Codable, Equatable {
+        let name: String
+    }
+}


### PR DESCRIPTION
Fixes #27 

To be honest, I don't quite understand what's going on to make this happen, and what the implications are.

I'm fiddling around with tests to reproduce the problem and catch it there, too.

In the meantime, pointers and feedback would be welcome :)