### PR TITLE
[Don't merge] Semver + header

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -2,14 +2,6 @@
 
 import PackageDescription
 
-#if compiler(>=5.7)
-let swiftMarkdownVersion = "release/5.7"
-#elseif compiler(>=5.6)
-let swiftMarkdownVersion = "release/5.6"
-#else
-fatalError("This version of MarkCodable requires Swift >= 5.6.")
-#endif
-
 let package = Package(
     name: "MarkCodable",
     platforms: [
@@ -33,7 +25,12 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-markdown.git", branch: swiftMarkdownVersion),
+        // swift-markdown doesn't have semantic version tags
+        // we should update the commit hash here from time to time.
+        .package(
+            url: "https://github.com/apple/swift-markdown.git",
+            revision: "52563fc74a540b29854fde20e836b27394be2749"
+        ),
     ],
     targets: [
         .executableTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -25,12 +25,8 @@ let package = Package(
         ),
     ],
     dependencies: [
-        // swift-markdown doesn't have semantic version tags
-        // we should update the commit hash here from time to time.
-        .package(
-            url: "https://github.com/apple/swift-markdown.git",
-            revision: "52563fc74a540b29854fde20e836b27394be2749"
-        ),
+        // Using a fork for the faux semantic version.
+        .package(url: "https://github.com/markcodable/swift-markdown.git", exact: "0.100.1"),
     ],
     targets: [
         .executableTarget(

--- a/README.md
+++ b/README.md
@@ -92,11 +92,9 @@ print(users[2]) // [userID: 2, name: Gui]
 
 Use the package directly in Xcode or via SwiftPM.
 
-For the time being the package depends on `swift-markdown` which does not support semantic versioning and thus `MarkCodable` also doesn't support it: [issue #15](https://github.com/icanzilb/MarkCodable/issues/15).
-
 ```swift
 dependencies: [
-  .package(url: "https://github.com/icanzilb/MarkCodable", branch: "main"),
+  .package(url: "https://github.com/icanzilb/MarkCodable", from: "0.6.0"),
 ]
 ```
 

--- a/Sources/MarkCodable/Decoder/MarkDecoder.swift
+++ b/Sources/MarkCodable/Decoder/MarkDecoder.swift
@@ -1,9 +1,4 @@
-//
-//  File.swift
-//  
-//
-//  Created by Marin Todorov on 8/31/22.
-//
+// See the LICENSE file for this code's license information.
 
 import Foundation
 import Markdown

--- a/Sources/MarkCodable/Decoder/MarkDecoding.swift
+++ b/Sources/MarkCodable/Decoder/MarkDecoding.swift
@@ -1,9 +1,4 @@
-//
-//  File.swift
-//  
-//
-//  Created by Marin Todorov on 8/31/22.
-//
+// See the LICENSE file for this code's license information.
 
 import Foundation
 

--- a/Sources/MarkCodable/Decoder/MarkKeyedDecoding.swift
+++ b/Sources/MarkCodable/Decoder/MarkKeyedDecoding.swift
@@ -1,9 +1,4 @@
-//
-//  File.swift
-//  
-//
-//  Created by Marin Todorov on 8/31/22.
-//
+// See the LICENSE file for this code's license information.
 
 import Foundation
 

--- a/Sources/MarkCodable/Decoder/MarkSingleValueDecoding.swift
+++ b/Sources/MarkCodable/Decoder/MarkSingleValueDecoding.swift
@@ -1,9 +1,4 @@
-//
-//  File.swift
-//  
-//
-//  Created by Marin Todorov on 9/3/22.
-//
+// See the LICENSE file for this code's license information.
 
 import Foundation
 

--- a/Sources/MarkCodable/Decoder/MarkUnkeyedDecoding.swift
+++ b/Sources/MarkCodable/Decoder/MarkUnkeyedDecoding.swift
@@ -1,9 +1,4 @@
-//
-//  File.swift
-//  
-//
-//  Created by Marin Todorov on 9/3/22.
-//
+// See the LICENSE file for this code's license information.
 
 import Foundation
 

--- a/Sources/MarkCodable/Encoder/MarkEncoder.swift
+++ b/Sources/MarkCodable/Encoder/MarkEncoder.swift
@@ -1,9 +1,4 @@
-//
-//  File.swift
-//  
-//
-//  Created by Marin Todorov on 8/31/22.
-//
+// See the LICENSE file for this code's license information.
 
 import Foundation
 import Markdown

--- a/Sources/MarkCodable/Encoder/MarkEncoding.swift
+++ b/Sources/MarkCodable/Encoder/MarkEncoding.swift
@@ -1,9 +1,4 @@
-//
-//  File.swift
-//  
-//
-//  Created by Marin Todorov on 8/31/22.
-//
+// See the LICENSE file for this code's license information.
 
 import Foundation
 

--- a/Sources/MarkCodable/Encoder/MarkKeyedEncoding.swift
+++ b/Sources/MarkCodable/Encoder/MarkKeyedEncoding.swift
@@ -1,9 +1,4 @@
-//
-//  File.swift
-//  
-//
-//  Created by Marin Todorov on 8/30/22.
-//
+// See the LICENSE file for this code's license information.
 
 import Foundation
 

--- a/Sources/MarkCodable/Encoder/MarkSingleValueEncoding.swift
+++ b/Sources/MarkCodable/Encoder/MarkSingleValueEncoding.swift
@@ -1,9 +1,4 @@
-//
-//  File.swift
-//  
-//
-//  Created by Marin Todorov on 9/2/22.
-//
+// See the LICENSE file for this code's license information.
 
 import Foundation
 

--- a/Sources/MarkCodable/Encoder/MarkUnkeyedEncoding.swift
+++ b/Sources/MarkCodable/Encoder/MarkUnkeyedEncoding.swift
@@ -1,9 +1,4 @@
-//
-//  File.swift
-//  
-//
-//  Created by Marin Todorov on 9/2/22.
-//
+// See the LICENSE file for this code's license information.
 
 import Foundation
 

--- a/Sources/MarkCodable/MarkCodable.swift
+++ b/Sources/MarkCodable/MarkCodable.swift
@@ -1,9 +1,4 @@
-//
-//  File.swift
-//  
-//
-//  Created by Marin Todorov on 9/1/22.
-//
+// See the LICENSE file for this code's license information.
 
 import Foundation
 

--- a/Sources/MarkTestApp/main.swift
+++ b/Sources/MarkTestApp/main.swift
@@ -1,9 +1,4 @@
-//
-//  File.swift
-//  
-//
-//  Created by Marin Todorov on 8/29/22.
-//
+// See the LICENSE file for this code's license information.
 
 import Foundation
 import MarkCodable

--- a/Tests/MarkCodableTests/MarkCoderTests.swift
+++ b/Tests/MarkCodableTests/MarkCoderTests.swift
@@ -1,3 +1,5 @@
+// See the LICENSE file for this code's license information.
+
 import XCTest
 @testable import MarkCodable
 

--- a/Tests/MarkCodableTests/Utility/TestData.swift
+++ b/Tests/MarkCodableTests/Utility/TestData.swift
@@ -1,9 +1,4 @@
-//
-//  File.swift
-//  
-//
-//  Created by Marin Todorov on 9/1/22.
-//
+// See the LICENSE file for this code's license information.
 
 import Foundation
 

--- a/Tests/MarkCodableTests/Utility/TestModels.swift
+++ b/Tests/MarkCodableTests/Utility/TestModels.swift
@@ -1,9 +1,4 @@
-//
-//  File.swift
-//  
-//
-//  Created by Marin Todorov on 9/1/22.
-//
+// See the LICENSE file for this code's license information.
 
 import Foundation
 import MarkCodable


### PR DESCRIPTION
This PR: 
 - Pin swift-markdown to the current commit hash
 - Removes the template headers from source
 - Cleans Package.swift from the swift-markdown branch names

Resolves #15 