### PR TITLE
Add Xcode 14.0.0 GM for Github action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: macos-12
     strategy:
       matrix:
-        xcode: ["13.4.1","14.0.0-beta"]
+        xcode: ["13.4.1","14.0.0"]
     steps:
       - uses: maxim-lobanov/setup-xcode@v1
         with:


### PR DESCRIPTION
`14.0.0-beta` not available anymore. Github Actions now support Xcode 14.0 GM.



Failed CI [run](https://github.com/rizwankce/MarkCodable/runs/8252965876?check_suite_focus=true)