### PR TITLE
Ignore SPM/swift build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,12 +39,12 @@ playground.xcworkspace
 # Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
 # Packages/
 # Package.pins
-# Package.resolved
+Package.resolved
 # *.xcodeproj
 #
 # Xcode automatically generates this directory with a .xcworkspacedata file and xcuserdata
 # hence it is not needed unless you have added a package configuration file to your project
-# .swiftpm
+.swiftpm
 
 .build/
 


### PR DESCRIPTION
Found that `Package.resolved` and `.swiftpm/` were showing as untracked.