### PR TITLE
Initial enum strategy

### DIFF
--- a/Sources/MarkCodable/Encoder/MarkEncoder.swift
+++ b/Sources/MarkCodable/Encoder/MarkEncoder.swift
@@ -20,7 +20,11 @@ import Markdown
 /// |true    |25    |EUR           |100400.0   |Main St.  |
 /// ```
 public class MarkEncoder {
-    
+    /// Markdown encoding errors.
+    public enum MarkEncodingError: Error {
+        case unsupportedValue(String)
+    }
+
     /// Any user info to pass along to encoding containers.
     var userInfo = UserInfo()
     
@@ -77,6 +81,10 @@ public class MarkEncoder {
         
         let encoding = MarkEncoding(codingPath: [], userInfo: userInfo, to: .init())
         try value.encode(to: encoding)
+
+        // Throws in case not all walked nested container keys ended up encoding values.
+        try encoding.data.validateTrackedKeys()
+
         keys = encoding.data.values.keys.sorted()
         values = [encoding.data.values]
         

--- a/Sources/MarkCodable/Encoder/MarkKeyedEncoding.swift
+++ b/Sources/MarkCodable/Encoder/MarkKeyedEncoding.swift
@@ -56,6 +56,9 @@ struct MarkKeyedEncoding<Key: CodingKey>: KeyedEncodingContainerProtocol {
         forKey key: Key
     ) -> KeyedEncodingContainer<NestedKey> {
         let container = MarkKeyedEncoding<NestedKey>(codingPath: codingPath + [key], userInfo: userInfo, to: data)
+        // Track nested containers, as part as a failsafe against enums.
+        data.addTrackedKey((codingPath + [key]).absoluteString)
+        
         return KeyedEncodingContainer(container)
     }
 

--- a/Sources/MarkCodable/MarkCodable.swift
+++ b/Sources/MarkCodable/MarkCodable.swift
@@ -40,6 +40,17 @@ final class CodingData {
             values[codingKey.absoluteString] = value
         }
     }
+
+    private var trackedKeys = [String]()
+    func addTrackedKey(_ key: String) {
+        trackedKeys.append(key)
+    }
+
+    func validateTrackedKeys() throws {
+        for trackedKey in trackedKeys where !values.keys.contains(trackedKey) {
+            throw MarkEncoder.MarkEncodingError.unsupportedValue("Warning: MarkCodable encountered a code path \(trackedKey) but no values were coded under that key.")
+        }
+    }
 }
 
 extension Array where Element == Appending {

--- a/Tests/MarkCodableTests/MarkCoderTests.swift
+++ b/Tests/MarkCodableTests/MarkCoderTests.swift
@@ -422,4 +422,118 @@ final class MarkCoderTests: XCTestCase {
         XCTAssertEqual(try encoder.encode(animalFarm1), markdown)
         XCTAssertEqual(try decoder.decode(AnimalFarm.self, string: markdown), animalFarm1)
     }
+
+    func testPlainEnumsThrowError() throws {
+        // Enum with and without associated values.
+        struct TestStruct: Codable {
+            enum Kind: Codable {
+                case basic(String, Int), intermediate
+            }
+            var kind: Kind
+        }
+
+        let encoder = MarkEncoder()
+        let test1 = TestStruct(kind: .intermediate)
+
+        XCTAssertThrowsError(try encoder.encode(test1), "Didn't throw for enum property") { error in
+            guard case MarkEncoder.MarkEncodingError.unsupportedValue(let message) = error else {
+                XCTFail("Didn't throw expected error")
+                return
+            }
+            guard message.contains("kind.intermediate") else {
+                XCTFail("Error message didn't contain the codingpath")
+                return
+            }
+        }
+
+        let test2 = TestStruct(kind: .basic("asd", 133))
+        XCTAssertThrowsError(try encoder.encode(test2), "Didn't throw for enum property") { error in
+            guard case MarkEncoder.MarkEncodingError.unsupportedValue(let message) = error else {
+                XCTFail("Didn't throw expected error")
+                return
+            }
+            guard message.contains("kind.basic") else {
+                XCTFail("Error message didn't contain the codingpath")
+                return
+            }
+        }
+    }
+
+    func testRawValueEnums() throws {
+        let encoder = MarkEncoder()
+        let decoder = MarkDecoder()
+
+        struct TestStruct: Codable, Equatable {
+            // String representable case
+            enum Kind: String, Codable, CaseIterable {
+                case basic, intermediate, advanced
+            }
+
+            // Int representable case
+            enum Count: Int, Codable, CaseIterable {
+                case low = 1
+                case high = 100
+            }
+            var kind: Kind
+            var count: Count
+        }
+
+        // Test enum cases encode correctly as values
+        let test1 = TestStruct(kind: .intermediate, count: .high)
+        let result = try encoder.encode(test1)
+        XCTAssertEqual(result, """
+        |count|kind        |
+        |-----|------------|
+        |100  |intermediate|
+        """)
+
+        // Test that enum values roundtrip successfully
+        for kind in TestStruct.Kind.allCases {
+            for count in TestStruct.Count.allCases {
+                let test = TestStruct(kind: kind, count: count)
+                let result = try encoder.encode(test)
+                let roundtrip = try decoder.decode(TestStruct.self, string: result)
+                XCTAssertEqual(roundtrip, test)
+            }
+        }
+    }
+
+    func testCustomCodingEnums() throws {
+        let encoder = MarkEncoder()
+        let decoder = MarkDecoder()
+
+        struct TestStruct: Codable, Equatable {
+            // Cases with custom coding
+            enum Kind: Codable, Equatable {
+                case none, url(String)
+
+                func encode(to encoder: Encoder) throws {
+                    var container = encoder.singleValueContainer()
+                    switch self {
+                    case .none: try container.encode("none")
+                    case .url(let string): try container.encode(string)
+                    }
+                }
+
+                init(from decoder: Decoder) throws {
+                    let value = try decoder.singleValueContainer().decode(String.self)
+                    self = value == "none" ? .none : .url(value)
+                }
+            }
+            var kind1: Kind
+            var kind2: Kind
+        }
+
+        // Test enum cases encode correctly as values
+        let test1 = TestStruct(kind1: .none, kind2: .url("http://host"))
+        let result = try encoder.encode(test1)
+        XCTAssertEqual(result, """
+        |kind1|kind2      |
+        |-----|-----------|
+        |none |http://host|
+        """)
+
+        // Test roundtrip
+        XCTAssertEqual(test1, try decoder.decode(TestStruct.self, string: result))
+    }
 }


### PR DESCRIPTION
Throws for unsupported enums, tests supported enums with raw value representable cases.

Raw value representable enum cases are encoded the same way as single value containers would encode any value:

```swift
struct TestStruct: Codable, Equatable {
    // String representable case
    enum Kind: String, Codable, CaseIterable {
        case basic, intermediate, advanced
    }

    // Int representable case
    enum Count: Int, Codable, CaseIterable {
        case low = 1
        case high = 100
    }
    var kind: Kind
    var count: Count
}

TestStruct(kind: .intermediate, count: .high)
```

Encodes to:

```
|count|kind        |
|-----|------------|
|100  |intermediate|
```