### PR TITLE
Refactor some repetitive code

### DIFF
--- a/Sources/MarkCodable/Encoder/MarkEncoder.swift
+++ b/Sources/MarkCodable/Encoder/MarkEncoder.swift
@@ -48,28 +48,7 @@ public class MarkEncoder {
         }
         keys = uniqueKeys.sorted()
         
-        let table = Markdown.Table(
-            header: Markdown.Table.Head(
-                keys.map { value -> Markdown.Table.Cell in
-                    Markdown.Table.Cell(Text(value))
-                }
-            ),
-            body: Markdown.Table.Body(
-                values.map({ row -> Markdown.Table.Row in
-                    Markdown.Table.Row(
-                        keys.map { key -> Markdown.Table.Cell in
-                            if let optionalValue = row[key], let value = optionalValue {
-                                return Markdown.Table.Cell(Text(value))
-                            } else {
-                                return Markdown.Table.Cell(Text(""))
-                            }
-                        }
-                    )
-                })
-            )
-        )
-        
-        return table.format()
+        return formattedMarkdownTable(keys, values)
     }
     
     /// Returns a Markdown-encoded representation of the value you supply.
@@ -88,6 +67,10 @@ public class MarkEncoder {
         keys = encoding.data.values.keys.sorted()
         values = [encoding.data.values]
         
+        return formattedMarkdownTable(keys, values)
+    }
+    
+    private func formattedMarkdownTable(_ keys: [String], _ values: [CodingValues]) -> String {
         let table = Markdown.Table(
             header: Markdown.Table.Head(
                 keys.map { value -> Markdown.Table.Cell in

--- a/Sources/MarkCodable/Encoder/MarkEncoding.swift
+++ b/Sources/MarkCodable/Encoder/MarkEncoding.swift
@@ -8,6 +8,11 @@ struct MarkEncoding: Encoder {
 
     var data: CodingData
 
+    public enum EncodingType {
+        case singleValue
+        case unkeyed
+    }
+    
     init(codingPath: CodingPath, userInfo: UserInfo, to data: CodingData) {
         self.codingPath = codingPath
         self.userInfo = userInfo
@@ -27,6 +32,25 @@ struct MarkEncoding: Encoder {
 
     func singleValueContainer() -> SingleValueEncodingContainer {
         return MarkSingleValueEncoding(codingPath: codingPath, userInfo: userInfo, to: data)
+    }
+    
+    func encode<T>(_ value: T, for encodingType: EncodingType) throws where T : Encodable {
+        switch value {
+        case let url as URL:
+            if encodingType == .singleValue {
+                data.isAppendingContainer.push(false)
+                defer { data.isAppendingContainer.pop() }
+            }
+            
+            data.encode(key: codingPath, value: url.absoluteString, appending: encodingType == .unkeyed)
+        default:
+            if encodingType == .unkeyed {
+                data.isAppendingContainer.push(true)
+                defer { data.isAppendingContainer.pop() }
+            }
+            
+            try value.encode(to: self)
+        }
     }
 }
 

--- a/Sources/MarkCodable/Encoder/MarkSingleValueEncoding.swift
+++ b/Sources/MarkCodable/Encoder/MarkSingleValueEncoding.swift
@@ -25,15 +25,7 @@ struct MarkSingleValueEncoding: SingleValueEncodingContainer {
     // https://github.com/icanzilb/MarkCodable/issues/10
     mutating func encode<T>(_ value: T) throws where T : Encodable {
         let markEncoding = MarkEncoding(codingPath: codingPath, userInfo: userInfo, to: data)
-
-        switch value {
-        case let url as URL:
-            data.isAppendingContainer.push(false)
-            defer { data.isAppendingContainer.pop() }
-
-            data.encode(key: codingPath, value: url.absoluteString)
-        default:
-            try value.encode(to: markEncoding)
-        }
+        
+        markEncoding.encode(value, for: .singleValue)
     }
 }

--- a/Sources/MarkCodable/Encoder/MarkUnkeyedEncoding.swift
+++ b/Sources/MarkCodable/Encoder/MarkUnkeyedEncoding.swift
@@ -22,17 +22,8 @@ struct MarkUnkeyedEncoding: UnkeyedEncodingContainer {
 
     mutating func encode<T>(_ value: T) throws where T : Encodable {
         let markEncoding = MarkEncoding(codingPath: codingPath, userInfo: userInfo, to: data)
-
-        switch value {
-        case let url as URL:
-            // Encode URLs as plain absolute URLs
-            data.encode(key: codingPath, value: url.absoluteString, appending: true)
-        default:
-            data.isAppendingContainer.push(true)
-            defer { data.isAppendingContainer.pop() }
-
-            try value.encode(to: markEncoding)
-        }
+        
+        markEncoding.encode(value, for: .unkeyed)
     }
 
     mutating func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type) -> KeyedEncodingContainer<NestedKey> where NestedKey : CodingKey {


### PR DESCRIPTION
Resolves #10 

1. Introduced `EncodingType` enum to refactor encode function for custom types based on encoding type (i.e `SingleValue` or `Unkeyed`) 
2. Refactored `Markdown.Table` creation logic to its own function as it was repeated twice in `MarkEncoder.swift` file.

Please let me know what you think 