### PR TITLE
Handles nil values encoded as empty strings

### DIFF
--- a/Sources/MarkCodable/Decoder/MarkDecoder.swift
+++ b/Sources/MarkCodable/Decoder/MarkDecoder.swift
@@ -35,6 +35,10 @@ public class MarkDecoder {
         case unsupportedFormat(String)
     }
 
+    enum MarkDecodingControlFlow: Error {
+        case representationForNil
+    }
+
     /// Decodes Markdown to a collection of same-type items.
     ///
     /// The method throws if `string` isn't in the expected Markdown format or any of the values cannot be decoded into its expected data type.

--- a/Sources/MarkCodable/Decoder/MarkKeyedDecoding.swift
+++ b/Sources/MarkCodable/Decoder/MarkKeyedDecoding.swift
@@ -47,7 +47,14 @@ struct MarkKeyedDecoding<Key: CodingKey>: KeyedDecodingContainerProtocol {
         }
 
         let decoding = MarkDecoding(codingPath: [key], userInfo: userInfo, from: nestedData)
-        let decodedValue = try T.init(from: decoding)
+        let decodedValue: T
+
+        do {
+            decodedValue = try T.init(from: decoding)
+        } catch MarkDecoder.MarkDecodingControlFlow.representationForNil {
+            // The nil value was represented as text
+            return nil
+        }
 
         // Optional collection cells that are empty decode as empty collections, e.g. `[]`. We rather want `nil` instead.
         if let collectionDecodable = decodedValue as? DecodableCollection,

--- a/Sources/MarkCodable/Decoder/MarkSingleValueDecoding.swift
+++ b/Sources/MarkCodable/Decoder/MarkSingleValueDecoding.swift
@@ -37,6 +37,9 @@ struct MarkSingleValueDecoding: SingleValueDecodingContainer {
 
     private func unbox<T: Decodable & StringInitializable>() throws -> T {
         guard let result = T(value) else {
+            guard !value.isEmpty else {
+                throw MarkDecoder.MarkDecodingControlFlow.representationForNil
+            }
             throw DecodingError.typeMismatch(T.self, DecodingError.Context(codingPath: codingPath, debugDescription: "Expected \(T.self) value at \(codingPath)"))
         }
         return result

--- a/Tests/MarkCodableTests/MarkCoderTests.swift
+++ b/Tests/MarkCodableTests/MarkCoderTests.swift
@@ -102,6 +102,44 @@ final class MarkCoderTests: XCTestCase {
         XCTAssertEqual(decoded4, [optional])
     }
 
+    func testCodingCGFloat() throws {
+        let encoder = MarkEncoder()
+        let decoder = MarkDecoder()
+
+        struct Test: Codable, Equatable {
+            var float: CGFloat?
+        }
+
+        // Optional nil value
+        let encoded = try encoder.encode([Test()])
+        let decoded = try decoder.decode([Test].self, from: encoded)
+        XCTAssertEqual(decoded, [Test()])
+
+        // Non-optional nil value
+        let encoded2 = try encoder.encode([Test(float: 1.0)])
+        let decoded2 = try decoder.decode([Test].self, from: encoded2)
+        XCTAssertEqual(decoded2, [Test(float: 1.0)])
+    }
+
+    func testCodingMixedOptionalValues() throws {
+        let encoder = MarkEncoder()
+        let decoder = MarkDecoder()
+
+        let house1 = OptionalHouse(isNewlyBuilt: true, name: "Supervilla", numberFloors: 3, streetNumber: 10)
+        let house2 = OptionalHouse(name: "Void")
+
+        let encoded1 = try encoder.encode([house2, house1])
+        XCTAssertEqual(encoded1, """
+        |isNewlyBuilt|name      |numberFloors|streetNumber|
+        |------------|----------|------------|------------|
+        |            |Void      |            |            |
+        |true        |Supervilla|3           |10          |
+        """)
+
+        let decoded1 = try decoder.decode([OptionalHouse].self, from: encoded1)
+        XCTAssertEqual(decoded1, [house2, house1])
+    }
+
     func testOptionalEncodingKeysDefaultTypes() throws {
         let encoder = MarkEncoder()
         let decoder = MarkDecoder()


### PR DESCRIPTION
Some numeric types (like `CGFloat`) don't have the custom decoder init that handles gracefully an empty string as representation for a `nil` value.