### PR TITLE
Fix decoder documentation link

### DIFF
--- a/Sources/MarkCodable/Decoder/MarkDecoder.swift
+++ b/Sources/MarkCodable/Decoder/MarkDecoder.swift
@@ -15,7 +15,7 @@ import Markdown
 /// ```
 /// > Note: The table might not be pretty formatted as long as its valid markdown, i.e. the pipes don't need to align vertically.
 ///
-/// Use ``decode(_:from:)-4ek7u`` to decode one or more values:
+/// Use ``decode(_:from:)`` to decode one or more values:
 ///
 /// ```swift
 /// let decoder = MarkDecoder()


### PR DESCRIPTION
I was checking out SPM [documentation](https://swiftpackageindex.com/markcodable/markcodable/0.6.9/documentation/markcodable/markdecoder) and figured out there was link which was not working. Not sure why we had this in first place. 